### PR TITLE
Fix missing CLI module

### DIFF
--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -1,0 +1,32 @@
+import { Command } from 'commander';
+import fs from 'fs';
+import path from 'path';
+
+export function runCLI(argv) {
+  const program = new Command();
+  program
+    .name('task-master')
+    .description('Simple task management CLI');
+
+  program
+    .command('list')
+    .description('List tasks from tasks.json')
+    .option('-f, --file <file>', 'Tasks file', 'tasks.json')
+    .action((opts) => {
+      const filePath = path.resolve(opts.file);
+      if (!fs.existsSync(filePath)) {
+        console.error(`Tasks file not found: ${filePath}`);
+        return;
+      }
+      try {
+        const tasks = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        for (const t of tasks) {
+          console.log(`${t.id}: ${t.title} [${t.status}]`);
+        }
+      } catch (err) {
+        console.error('Failed to read tasks:', err);
+      }
+    });
+
+  program.parse(argv);
+}


### PR DESCRIPTION
## Summary
- add a minimal task CLI implementation so `scripts/dev.js` works

## Testing
- `npm run typecheck`
- `node scripts/dev.js list`


------
https://chatgpt.com/codex/tasks/task_e_68410c6fd488832294592a005afb3819