### PR TITLE
Fix CLI import issue

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -13,7 +13,7 @@ if (process.env.DEBUG === '1') {
 	console.error('DEBUG - dev.js received args:', process.argv.slice(2));
 }
 
-import { runCLI } from './modules/commands.js';
+const { runCLI } = require('./modules/commands.js');
 
 // Run the CLI with the process arguments
 runCLI(process.argv);

--- a/scripts/modules/commands.js
+++ b/scripts/modules/commands.js
@@ -1,8 +1,8 @@
-import { Command } from 'commander';
-import fs from 'fs';
-import path from 'path';
+const { Command } = require('commander');
+const fs = require('fs');
+const path = require('path');
 
-export function runCLI(argv) {
+function runCLI(argv) {
   const program = new Command();
   program
     .name('task-master')
@@ -30,3 +30,5 @@ export function runCLI(argv) {
 
   program.parse(argv);
 }
+
+module.exports = { runCLI };


### PR DESCRIPTION
## Summary
- update `scripts/dev.js` to use `require`
- switch `scripts/modules/commands.js` to CommonJS export

## Testing
- `npm run list`

------
https://chatgpt.com/codex/tasks/task_e_68410f4b946c8322809e452798601b5c