### PR TITLE
Show majority decision summary

### DIFF
--- a/components/UserDecisionDashboard.tsx
+++ b/components/UserDecisionDashboard.tsx
@@ -682,6 +682,18 @@ export default function UserDecisionDashboard() {
                         <h3 className="text-xl sm:text-2xl font-bold mb-4 sm:mb-6">
                           Decision Analysis
                         </h3>
+                        {majorityDecision && (
+                          <p className="text-center text-sm mb-4">
+                            Most personalities chose
+                            <span
+                              className="mx-1 px-2 py-1 rounded-full text-white"
+                              style={{ backgroundColor: majorityColor }}
+                            >
+                              {majorityDecision}
+                            </span>
+                            ({decisionCounts[majorityDecision]} of {results.length})
+                          </p>
+                        )}
                         <div className="space-y-6">
                           {/* Top 3 Decisions */}
                           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 mb-6">

--- a/tests/logic.test.ts
+++ b/tests/logic.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { calculateScore, getDecision } from '../models/decision/logic';
+import {
+  calculateScore,
+  getDecision,
+  calculateMajorityDecision,
+} from '../models/decision/logic';
 import { Weights, Inputs } from '../models/decision/types';
 
 describe('calculateScore', () => {
@@ -29,5 +33,34 @@ describe('getDecision', () => {
     expect(getDecision(0.56).text).toBe('Implement with Oversight');
     expect(getDecision(0.4).text).toBe('Request Clarification');
     expect(getDecision(0.2).text).toBe('Delay or Disengage');
+  });
+});
+
+describe('calculateMajorityDecision', () => {
+  it('identifies the most common decision', () => {
+    const results = [
+      {
+        name: 'A',
+        score: 0.8,
+        decision: 'Proceed Strategically',
+        color: '#4ade80',
+      },
+      {
+        name: 'B',
+        score: 0.82,
+        decision: 'Proceed Strategically',
+        color: '#4ade80',
+      },
+      {
+        name: 'C',
+        score: 0.45,
+        decision: 'Request Clarification',
+        color: '#facc15',
+      },
+    ];
+
+    const { decision, counts } = calculateMajorityDecision(results);
+    expect(decision).toBe('Proceed Strategically');
+    expect(counts['Proceed Strategically']).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- show majority decision text in the results tab so users know the most common recommendation
- test calculateMajorityDecision utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841111651808322ba1672dc6ffc741b