### PR TITLE
Show majority decision summary

### DIFF
--- a/components/UserDecisionDashboard.tsx
+++ b/components/UserDecisionDashboard.tsx
@@ -287,6 +287,31 @@ const getRandomFamousPerson = (mbtiType: string): string => {
   return people[Math.floor(Math.random() * people.length)];
 };
 
+// Mapping of MBTI types to placeholder image seeds
+const mbtiImageSeeds: Record<string, string> = {
+  INTJ: "architect",
+  ENTJ: "leader",
+  INTP: "scientist",
+  ENTP: "inventor",
+  INFJ: "visionary",
+  ENFJ: "coach",
+  INFP: "poet",
+  ENFP: "creative",
+  ISTJ: "organizer",
+  ESTJ: "executive",
+  ISFJ: "caregiver",
+  ESFJ: "supporter",
+  ISTP: "craftsman",
+  ESTP: "entrepreneur",
+  ISFP: "artist",
+  ESFP: "performer",
+};
+
+const getMBTIImage = (mbtiType: string): string => {
+  const seed = mbtiImageSeeds[mbtiType] || mbtiType.toLowerCase();
+  return `https://picsum.photos/seed/${seed}/100/100`;
+};
+
 // Types for the charts component
 type ChartProps = {
   results: DecisionService.SimulationResult[];
@@ -682,6 +707,18 @@ export default function UserDecisionDashboard() {
                         <h3 className="text-xl sm:text-2xl font-bold mb-4 sm:mb-6">
                           Decision Analysis
                         </h3>
+                        {majorityDecision && (
+                          <p className="text-center text-sm mb-4">
+                            Most personalities chose
+                            <span
+                              className="mx-1 px-2 py-1 rounded-full text-white"
+                              style={{ backgroundColor: majorityColor }}
+                            >
+                              {majorityDecision}
+                            </span>
+                            ({decisionCounts[majorityDecision]} of {results.length})
+                          </p>
+                        )}
                         <div className="space-y-6">
                           {/* Top 3 Decisions */}
                           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 mb-6">
@@ -891,13 +928,19 @@ export default function UserDecisionDashboard() {
                     {Object.entries(DecisionService.mbtiDescriptions).map(
                       ([type, info]) => {
                         const famousPerson = getRandomFamousPerson(type);
+                        const img = getMBTIImage(type);
                         return (
                           <div
                             key={type}
                             className="p-4 rounded-xl shadow-sm border border-gray-100 bg-white"
                             style={{ borderLeft: `4px solid ${info.color}` }}
                           >
-                            <div className="flex items-center justify-between">
+                            <div className="flex items-start gap-3">
+                              <img
+                                src={img}
+                                alt={`${type} icon`}
+                                className="w-12 h-12 rounded-full object-cover"
+                              />
                               <div>
                                 <h4
                                   className="font-bold mb-2"

--- a/tests/logic.test.ts
+++ b/tests/logic.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { calculateScore, getDecision } from '../models/decision/logic';
+import {
+  calculateScore,
+  getDecision,
+  calculateMajorityDecision,
+} from '../models/decision/logic';
 import { Weights, Inputs } from '../models/decision/types';
 
 describe('calculateScore', () => {
@@ -29,5 +33,34 @@ describe('getDecision', () => {
     expect(getDecision(0.56).text).toBe('Implement with Oversight');
     expect(getDecision(0.4).text).toBe('Request Clarification');
     expect(getDecision(0.2).text).toBe('Delay or Disengage');
+  });
+});
+
+describe('calculateMajorityDecision', () => {
+  it('identifies the most common decision', () => {
+    const results = [
+      {
+        name: 'A',
+        score: 0.8,
+        decision: 'Proceed Strategically',
+        color: '#4ade80',
+      },
+      {
+        name: 'B',
+        score: 0.82,
+        decision: 'Proceed Strategically',
+        color: '#4ade80',
+      },
+      {
+        name: 'C',
+        score: 0.45,
+        decision: 'Request Clarification',
+        color: '#facc15',
+      },
+    ];
+
+    const { decision, counts } = calculateMajorityDecision(results);
+    expect(decision).toBe('Proceed Strategically');
+    expect(counts['Proceed Strategically']).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- show majority decision text in the results tab so users know the most common recommendation
- test calculateMajorityDecision utility
- add placeholder images for each MBTI type in the personalities tab

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6841111651808322ba1672dc6ffc741b