### PR TITLE
Refactor UI widgets into separate components

### DIFF
--- a/components/IOSStatusBar.tsx
+++ b/components/IOSStatusBar.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { BsClockFill, BsGeoAlt } from "react-icons/bs";
+
+const IOSStatusBar: React.FC = () => {
+  const [time, setTime] = useState<string>("");
+
+  useEffect(() => {
+    const updateTime = () => {
+      const now = new Date();
+      setTime(now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }));
+    };
+
+    updateTime();
+    const interval = setInterval(updateTime, 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="sticky top-0 z-50 bg-[#007aff] text-white px-4 py-2 flex justify-between items-center">
+      <div className="text-xs font-bold">{time}</div>
+      <div className="flex items-center space-x-1">
+        <div className="w-3 h-3">
+          <BsClockFill className="w-full h-full" />
+        </div>
+        <div className="w-4 h-4">
+          <BsGeoAlt className="w-full h-full" />
+        </div>
+        <div className="w-6 h-5">
+          <div className="h-full relative">
+            <div className="absolute top-0 left-0 right-0 bottom-0 flex items-center px-0.5">
+              <div className="h-2 rounded-sm w-1 bg-white mx-0.5" />
+              <div className="h-3 rounded-sm w-1 bg-white mx-0.5" />
+              <div className="h-4 rounded-sm w-1 bg-white mx-0.5" />
+              <div className="h-2.5 rounded-sm w-1 bg-white mx-0.5" />
+            </div>
+          </div>
+        </div>
+        <div className="w-6 h-3 border border-white rounded-sm relative">
+          <div className="absolute right-0 top-0 bottom-0 bg-white w-3 mr-px my-px rounded-sm" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default IOSStatusBar;

--- a/components/SliderInput.tsx
+++ b/components/SliderInput.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import * as DecisionService from "@/lib/decisionMatrixService";
+
+export interface SliderInputProps {
+  id: string;
+  label: string;
+  value: number;
+  onChange: (value: string) => void;
+  info: DecisionService.FactorInfo;
+}
+
+const SliderInput: React.FC<SliderInputProps> = ({ id, label, value, onChange, info }) => (
+  <div className="flex flex-col mb-5">
+    <div className="flex justify-between items-center mb-2">
+      <label htmlFor={id} className="font-medium text-md text-[#1d1d1f]">
+        {info.label}
+      </label>
+      <Popover>
+        <PopoverTrigger asChild>
+          <button className="text-sm text-gray-500 cursor-help bg-[#f2f2f7] w-6 h-6 flex items-center justify-center rounded-full">
+            ⓘ
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="max-w-xs bg-[#f5f5f7] border border-[#e6e6e6] shadow-lg rounded-xl p-3">
+          <p className="font-medium text-[#1d1d1f]">{info.description}</p>
+          <div className="mt-2 text-sm grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="bg-[#f9f9fb] p-2 rounded-lg border border-[#e6e6e6]">
+              <span className="font-bold text-[#1d1d1f]">Low:</span> {info.lowDesc}
+            </div>
+            <div className="bg-[#f9f9fb] p-2 rounded-lg border border-[#e6e6e6]">
+              <span className="font-bold text-[#1d1d1f]">High:</span> {info.highDesc}
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+    <div className="flex items-center space-x-4">
+      <input
+        id={id}
+        type="range"
+        min="0"
+        max="1"
+        step="0.05"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="flex-grow appearance-none h-6 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#007aff]/20"
+        style={{
+          WebkitAppearance: "none",
+          background: `linear-gradient(to right, #007aff ${value * 100}%, #e5e5ea ${value * 100}%)`,
+          height: "0.75rem",
+          borderRadius: "999px",
+        }}
+      />
+      <span className="w-12 text-right font-mono text-[#007aff] font-semibold">
+        {(value * 100).toFixed(0)}%
+      </span>
+    </div>
+  </div>
+);
+
+export default SliderInput;

--- a/components/Stepper.tsx
+++ b/components/Stepper.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import React from "react";
+import { cn } from "@/lib/utils";
+
+export const StepperContainer: React.FC<{ children: React.ReactNode; className?: string }> = ({
+  children,
+  className,
+}) => <div className={cn("flex w-full", className)}>{children}</div>;
+
+export const StepperStep: React.FC<{
+  isActive: boolean;
+  isCompleted: boolean;
+  stepNumber: number;
+  title: string;
+  description: string;
+}> = ({ isActive, isCompleted, stepNumber, title, description }) => (
+  <div className="flex-1 relative">
+    <div className="flex items-center">
+      <div
+        className={cn(
+          "w-8 h-8 rounded-full flex items-center justify-center border-2 z-10 bg-white",
+          isActive
+            ? "border-indigo-500 text-indigo-500 shadow-md"
+            : isCompleted
+            ? "border-green-500 bg-green-500 text-white"
+            : "border-gray-300 text-gray-400"
+        )}
+      >
+        {isCompleted ? (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fillRule="evenodd"
+              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+              clipRule="evenodd"
+            />
+          </svg>
+        ) : (
+          <span>{stepNumber}</span>
+        )}
+      </div>
+      <div
+        className={cn(
+          "flex-1 h-0.5",
+          isCompleted ? "bg-green-500" : "bg-gray-200"
+        )}
+      ></div>
+    </div>
+    <div className="mt-2">
+      <div
+        className={cn(
+          "text-sm font-medium",
+          isActive
+            ? "text-indigo-600"
+            : isCompleted
+            ? "text-green-600"
+            : "text-gray-500"
+        )}
+      >
+        {title}
+      </div>
+      <div className="text-xs text-gray-500">{description}</div>
+    </div>
+  </div>
+);

--- a/components/StyledTabs.tsx
+++ b/components/StyledTabs.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+
+const StyledTabs: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="w-full overflow-hidden">
+    <style jsx>{`
+      :global([data-state="active"]) {
+        background-color: hsl(var(--primary) / 0.1) !important;
+        color: hsl(var(--primary)) !important;
+        font-weight: 600;
+      }
+    `}</style>
+    {children}
+  </div>
+);
+
+export default StyledTabs;

--- a/components/UserDecisionCharts.tsx
+++ b/components/UserDecisionCharts.tsx
@@ -31,7 +31,7 @@ import { hierarchy } from "d3-hierarchy";
 import { LinkHorizontal } from "@visx/shape";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
-import { StyledTabs } from "./UserDecisionDashboard";
+import StyledTabs from "./StyledTabs";
 import * as DecisionService from "@/lib/decisionMatrixService";
 
 // Import specific types


### PR DESCRIPTION
## Summary
- add reusable components for status bar, stepper, slider input and tab styling
- update chart file to import new `StyledTabs`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841168e49b0832295c5533d0aa80ba4