### PR TITLE
Add client directive for dashboard charts

### DIFF
--- a/components/UserDecisionCharts.tsx
+++ b/components/UserDecisionCharts.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect } from "react";
 import {
   BarChart,

--- a/components/UserDecisionDashboard.tsx
+++ b/components/UserDecisionDashboard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState, useEffect, useRef } from "react";
 import {
   Card,


### PR DESCRIPTION
## Summary
- add missing `use client` pragma to dashboard and charts

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684129c1e5c48322b8351f5385217105