### PR TITLE
Fix missing Radix icons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "team-decision-simulator",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-popover": "^1.1.7",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slider": "^1.3.5",
@@ -1457,6 +1458,15 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@radix-ui/react-icons": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+      "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@radix-ui/react-id": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-popover": "^1.1.7",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slider": "^1.3.5",


### PR DESCRIPTION
## Summary
- install `@radix-ui/react-icons`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841389b10cc8322b5574da740f8d32a