### PR TITLE
Improve MBTI selector and enlarge tabs

### DIFF
--- a/components/UserDecisionDashboard.tsx
+++ b/components/UserDecisionDashboard.tsx
@@ -630,7 +630,13 @@ export default function UserDecisionDashboard() {
           <div className="absolute inset-0 bg-grid opacity-10"></div>
           <CardContent className="p-0 relative">
             <div className="px-4 pt-4 flex justify-end">
-              <div className="w-32">
+              <div className="w-32 flex flex-col items-start">
+                <label
+                  htmlFor="user-mbti"
+                  className="text-xs font-medium text-gray-600 mb-1"
+                >
+                  MBTI Type
+                </label>
                 <Select
                   value={userMBTI}
                   onValueChange={(v) => setUserMBTI(v as MBTIType)}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -42,7 +42,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex min-h-[44px] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-3 py-2 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 md:min-h-[36px] md:px-4 md:py-1.5 lg:px-6",
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex min-h-[52px] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-4 py-2.5 text-base font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 md:min-h-[44px] md:px-5 md:py-2 lg:px-7",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- enlarge tab triggers for easier tapping
- label the MBTI type selector for clarity

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68413e3d0478832290b2d398f4b74f9b