### PR TITLE
Add Office character mapping

### DIFF
--- a/components/UserDecisionDashboard.tsx
+++ b/components/UserDecisionDashboard.tsx
@@ -300,6 +300,26 @@ const famousPeopleByMBTI: Record<string, string[]> = {
   ],
 };
 
+// Mapping of MBTI types to characters from The Office
+const officeCharactersByMBTI: Record<string, string[]> = {
+  INTJ: ["Oscar Martinez"],
+  ENTJ: ["Jan Levinson"],
+  INTP: ["Gabe Lewis"],
+  ENTP: ["Jim Halpert"],
+  INFJ: ["Toby Flenderson"],
+  ENFJ: ["Andy Bernard"],
+  INFP: ["Erin Hannon"],
+  ENFP: ["Michael Scott"],
+  ISTJ: ["Dwight Schrute"],
+  ESTJ: ["Angela Martin"],
+  ISFJ: ["Pam Beesly"],
+  ESFJ: ["Phyllis Vance"],
+  ISTP: ["Stanley Hudson"],
+  ESTP: ["Todd Packer"],
+  ISFP: ["Holly Flax"],
+  ESFP: ["Kelly Kapoor"],
+};
+
 // Helper function to get a random famous person for a given MBTI type
 const getRandomFamousPerson = (mbtiType: string): string => {
   const people = famousPeopleByMBTI[mbtiType] || [];
@@ -660,7 +680,7 @@ export default function UserDecisionDashboard() {
               className="w-full"
             >
               <div className="sticky top-0 z-10 bg-white/90 backdrop-blur-md border-b border-gray-100 px-4 pt-4">
-                <TabsList className="grid w-full grid-cols-4 mb-2 bg-[#f2f2f7] p-1 rounded-full h-auto overflow-hidden">
+                <TabsList className="grid w-full grid-cols-5 mb-2 bg-[#f2f2f7] p-1 rounded-full h-auto overflow-hidden">
                   <TabsTrigger
                     value="scenarios"
                     className="rounded-full py-2 px-3 data-[state=active]:bg-white data-[state=active]:shadow-sm data-[state=active]:text-[#007aff] data-[state=active]:font-medium"
@@ -695,6 +715,15 @@ export default function UserDecisionDashboard() {
                     <div className="flex flex-col items-center gap-1">
                       <MdPsychology className="h-4 w-4" />
                       <span className="text-xs">Types</span>
+                    </div>
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="office"
+                    className="rounded-full py-2 px-3 data-[state=active]:bg-white data-[state=active]:shadow-sm data-[state=active]:text-[#007aff] data-[state=active]:font-medium"
+                  >
+                    <div className="flex flex-col items-center gap-1">
+                      <BsPeople className="h-4 w-4" />
+                      <span className="text-xs">Office</span>
                     </div>
                   </TabsTrigger>
                 </TabsList>
@@ -1059,6 +1088,46 @@ export default function UserDecisionDashboard() {
                         );
                       }
                     )}
+                  </div>
+                </TabsContent>
+
+                {/* The Office Characters Tab */}
+                <TabsContent value="office" className="space-y-4 relative">
+                  <div className="absolute inset-0 opacity-[0.06] pointer-events-none overflow-hidden">
+                    <div className="absolute bottom-10 left-10 w-[120px] h-[120px] bg-gradient-to-br from-purple-600 to-blue-500 rounded-full blur-xl"></div>
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    {Object.entries(DecisionService.mbtiDescriptions).map(([type, info]) => {
+                      const characters = officeCharactersByMBTI[type] || [];
+                      if (characters.length === 0) return null;
+                      const img = getMBTIImage(type);
+                      return (
+                        <div
+                          key={type}
+                          className={cn(
+                            "p-4 rounded-xl shadow-sm bg-white",
+                            type === userMBTI ? "border-2 border-[#007aff]" : "border border-gray-100"
+                          )}
+                          style={{ borderLeft: `4px solid ${info.color}` }}
+                        >
+                          <div className="flex items-start gap-3">
+                            <Image
+                              src={img}
+                              alt={`${type} icon`}
+                              width={48}
+                              height={48}
+                              className="w-12 h-12 rounded-full object-cover"
+                            />
+                            <div>
+                              <h4 className="font-bold mb-2" style={{ color: info.color }}>
+                                {info.name}
+                              </h4>
+                              <p className="text-sm text-gray-600">{characters.join(', ')}</p>
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
                   </div>
                 </TabsContent>
               </div>


### PR DESCRIPTION
## Summary
- show MBTI types with corresponding characters from *The Office*
- update tabs to include new "Office" tab
- display office character list for each MBTI type

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841fc3d6cc483228d7740eaf81c4848