### PR TITLE
Add Office mapping inside results

### DIFF
--- a/components/UserDecisionCharts.tsx
+++ b/components/UserDecisionCharts.tsx
@@ -343,6 +343,26 @@ const famousPeopleByMBTI: Record<string, string[]> = {
   ],
 };
 
+// Mapping of MBTI types to characters from The Office
+const officeCharactersByMBTI: Record<string, string[]> = {
+  INTJ: ["Oscar Martinez"],
+  ENTJ: ["Jan Levinson"],
+  INTP: ["Gabe Lewis"],
+  ENTP: ["Jim Halpert"],
+  INFJ: ["Toby Flenderson"],
+  ENFJ: ["Andy Bernard"],
+  INFP: ["Erin Hannon"],
+  ENFP: ["Michael Scott"],
+  ISTJ: ["Dwight Schrute"],
+  ESTJ: ["Angela Martin"],
+  ISFJ: ["Pam Beesly"],
+  ESFJ: ["Phyllis Vance"],
+  ISTP: ["Stanley Hudson"],
+  ESTP: ["Todd Packer"],
+  ISFP: ["Holly Flax"],
+  ESFP: ["Kelly Kapoor"],
+};
+
 // Harry Potter Houses mapping for MBTI types
 const harryPotterHousesByMBTI: Record<
   string,
@@ -965,7 +985,7 @@ const UserDecisionCharts: React.FC<Props> = ({
       onValueChange={(value) => setActiveTab(value)}
     >
       <div className="w-full max-w-full overflow-hidden">
-        <TabsList className="w-full mb-4 bg-[#4455a6]/10 p-1 rounded-xl overflow-hidden grid grid-cols-2 sm:grid-cols-3 md:grid-cols-7 gap-1">
+        <TabsList className="w-full mb-4 bg-[#4455a6]/10 p-1 rounded-xl overflow-hidden grid grid-cols-2 sm:grid-cols-3 md:grid-cols-8 gap-1">
           <TabsTrigger
             value="bar"
             className={cn(
@@ -991,6 +1011,19 @@ const UserDecisionCharts: React.FC<Props> = ({
             )}
           >
             Houses
+          </TabsTrigger>
+          <TabsTrigger
+            value="office"
+            className={cn(
+              "rounded-lg font-semibold text-[10px] xxs:text-[11px] xs:text-xs md:text-sm px-1 py-1.5",
+              "data-[state=active]:bg-[#4455a6]",
+              "data-[state=active]:text-white",
+              "data-[state=active]:shadow-lg",
+              "data-[state=inactive]:py-1",
+              "transition-all duration-200"
+            )}
+          >
+            Office
           </TabsTrigger>
           <TabsTrigger
             value="radar"
@@ -1765,6 +1798,27 @@ const UserDecisionCharts: React.FC<Props> = ({
               </p>
             </div>
           </div>
+        </div>
+      </TabsContent>
+
+      <TabsContent value="office" className="mt-2">
+        <div className="mb-4 text-sm text-[#4455a6] font-medium bg-[#4455a6]/5 p-3 rounded-lg">
+          Which characters from The Office correspond to each MBTI type.
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {Object.entries(officeCharactersByMBTI).map(([type, characters]) => (
+            <div
+              key={type}
+              className="p-4 rounded-xl shadow-sm bg-white border border-gray-100"
+              style={{ borderLeft: `4px solid ${getMBTIColor(type)}` }}
+            >
+              <h4 className="font-bold mb-2" style={{ color: getMBTIColor(type) }}>
+                {type}
+              </h4>
+              <p className="text-sm text-gray-600">{characters.join(', ')}</p>
+            </div>
+          ))}
         </div>
       </TabsContent>
 

--- a/components/UserDecisionDashboard.tsx
+++ b/components/UserDecisionDashboard.tsx
@@ -300,6 +300,7 @@ const famousPeopleByMBTI: Record<string, string[]> = {
   ],
 };
 
+
 // Helper function to get a random famous person for a given MBTI type
 const getRandomFamousPerson = (mbtiType: string): string => {
   const people = famousPeopleByMBTI[mbtiType] || [];
@@ -1002,63 +1003,58 @@ export default function UserDecisionDashboard() {
                   )}
                 </TabsContent>
 
+
                 {/* Personalities Tab */}
-                <TabsContent
-                  value="personalities"
-                  className="space-y-4 relative"
-                >
+                <TabsContent value="personalities" className="space-y-4 relative">
                   <div className="absolute inset-0 opacity-[0.06] pointer-events-none overflow-hidden">
                     <div className="absolute bottom-10 right-10 w-[120px] h-[120px] bg-gradient-to-tr from-indigo-600 to-blue-500 rounded-full blur-xl"></div>
                   </div>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                    {Object.entries(DecisionService.mbtiDescriptions).map(
-                      ([type, info]) => {
-                        const famousPerson = famousPeopleMap[type];
-                        const img = getMBTIImage(type);
-                        return (
-                          <div
-                            key={type}
-                            className={cn(
-                              "p-4 rounded-xl shadow-sm bg-white",
-                              type === userMBTI
-                                ? "border-2 border-[#007aff]"
-                                : "border border-gray-100"
-                            )}
-                            style={{ borderLeft: `4px solid ${info.color}` }}
-                          >
-                            <div className="flex items-start gap-3">
-                              <Image
-                                src={img}
-                                alt={`${type} icon`}
-                                width={48}
-                                height={48}
-                                className="w-12 h-12 rounded-full object-cover"
-                              />
-                              <div>
-                                <h4
-                                  className="font-bold mb-2"
-                                  style={{ color: info.color }}
-                                >
-                                  {info.name}
-                                </h4>
-                                <p className="text-sm text-gray-600">
-                                  {info.description}
-                                </p>
-                              </div>
-                            </div>
-                            {type === userMBTI && (
-                              <p className="text-xs font-semibold text-[#007aff] mt-1">
-                                Your Type
+                    {Object.entries(DecisionService.mbtiDescriptions).map(([type, info]) => {
+                      const famousPerson = famousPeopleMap[type];
+                      const img = getMBTIImage(type);
+                      return (
+                        <div
+                          key={type}
+                          className={cn(
+                            "p-4 rounded-xl shadow-sm bg-white",
+                            type === userMBTI
+                              ? "border-2 border-[#007aff]"
+                              : "border border-gray-100"
+                          )}
+                          style={{ borderLeft: `4px solid ${info.color}` }}
+                        >
+                          <div className="flex items-start gap-3">
+                            <Image
+                              src={img}
+                              alt={`${type} icon`}
+                              width={48}
+                              height={48}
+                              className="w-12 h-12 rounded-full object-cover"
+                            />
+                            <div>
+                              <h4
+                                className="font-bold mb-2"
+                                style={{ color: info.color }}
+                              >
+                                {info.name}
+                              </h4>
+                              <p className="text-sm text-gray-600">
+                                {info.description}
                               </p>
-                            )}
-                            <p className="text-xs mt-2 italic text-gray-500">
-                              {famousPerson &&
-                                `Famous example: ${famousPerson}`}
-                            </p>
+                            </div>
                           </div>
-                        );
-                      }
-                    )}
+                          {type === userMBTI && (
+                            <p className="text-xs font-semibold text-[#007aff] mt-1">
+                              Your Type
+                            </p>
+                          )}
+                          <p className="text-xs mt-2 italic text-gray-500">
+                            {famousPerson && `Famous example: ${famousPerson}`}
+                          </p>
+                        </div>
+                      );
+                    })}
                   </div>
                 </TabsContent>
               </div>


### PR DESCRIPTION
## Summary
- show mapping of MBTI types to The Office characters in the Results section
- revert the Types tab to a single view without subtabs

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841fc3d6cc483228d7740eaf81c4848