### PR TITLE
Fix GitHub Actions ESLint errors - Missing icon imports

### DIFF
--- a/components/UserDecisionDashboard.tsx
+++ b/components/UserDecisionDashboard.tsx
@@ -26,7 +26,7 @@ import * as DecisionService from "@/lib/decisionMatrixService";
 import { Slider } from "@/components/ui/slider";
 // Import react-icons
 import { FaBrain, FaCheck } from "react-icons/fa";
-import { BsFileText } from "react-icons/bs";
+import { BsFileText, BsClockFill, BsGeoAlt } from "react-icons/bs";
 import { IoMdAnalytics } from "react-icons/io";
 import {
   MdOutlineAssessment,


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
GitHub Actions workflow was failing with the error:
```
The strategy configuration was canceled because "test._18_x" failed
```

The root cause was ESLint errors in `UserDecisionDashboard.tsx`:
- `'BsClockFill' is not defined. react/jsx-no-undef`
- `'BsGeoAlt' is not defined. react/jsx-no-undef`

### Solution
Added missing imports for `BsClockFill` and `BsGeoAlt` from the `react-icons/bs` package.

### Changes
- ✅ Added missing imports: `BsClockFill, BsGeoAlt` to `components/UserDecisionDashboard.tsx`
- ✅ Fixes ESLint errors that were causing test job failures
- ✅ Prevents strategy matrix cancellation in GitHub Actions
- ✅ Allows all workflow jobs (test, build, deploy) to run successfully

### Testing
- [x] ESLint passes locally: `npm run lint` ✅
- [x] Tests pass locally: `npm test` ✅
- [x] GitHub Actions workflow completes successfully

### Impact
- Resolves GitHub Actions workflow failures
- Both Node.js 18.x and 20.x test jobs now pass
- Build and deployment jobs can proceed normally

### Files Changed
- `components/UserDecisionDashboard.tsx` - Added missing icon imports

Fixes the GitHub Actions strategy matrix cancellation issue.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author